### PR TITLE
[API-38] Filter by started/ended dates - Take #2

### DIFF
--- a/app/Filters/Contracts/OccurrenceFilter.php
+++ b/app/Filters/Contracts/OccurrenceFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace VOSTPT\Filters\Contracts;
 
+use Carbon\Carbon;
+
 interface OccurrenceFilter extends Filter
 {
     /**
@@ -59,4 +61,22 @@ interface OccurrenceFilter extends Filter
      * @return self
      */
     public function withParishes(...$parishes): self;
+
+    /**
+     * Include started at date for filtering.
+     *
+     * @param Carbon $startedAt
+     *
+     * @return self
+     */
+    public function withStartedAt(Carbon $startedAt): self;
+
+    /**
+     * Include ended at date for filtering.
+     *
+     * @param Carbon $endedAt
+     *
+     * @return self
+     */
+    public function withEndedAt(Carbon $endedAt): self;
 }

--- a/app/Filters/OccurrenceFilter.php
+++ b/app/Filters/OccurrenceFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace VOSTPT\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 
 class OccurrenceFilter extends Filter implements Contracts\OccurrenceFilter
@@ -49,6 +50,20 @@ class OccurrenceFilter extends Filter implements Contracts\OccurrenceFilter
      * @var array
      */
     private $parishes = [];
+
+    /**
+     * Started at date filtering.
+     *
+     * @var Carbon
+     */
+    private $startedAt;
+
+    /**
+     * Ended at date filtering.
+     *
+     * @var Carbon
+     */
+    private $endedAt;
 
     /**
      * {@inheritDoc}
@@ -183,6 +198,26 @@ class OccurrenceFilter extends Filter implements Contracts\OccurrenceFilter
     /**
      * {@inheritDoc}
      */
+    public function withStartedAt(Carbon $startedAt): Contracts\OccurrenceFilter
+    {
+        $this->startedAt = $startedAt;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function withEndedAt(Carbon $endedAt): Contracts\OccurrenceFilter
+    {
+        $this->endedAt = $endedAt;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function apply(Builder $builder): void
     {
         parent::apply($builder);
@@ -223,6 +258,16 @@ class OccurrenceFilter extends Filter implements Contracts\OccurrenceFilter
         if ($this->parishes) {
             $builder->whereIn('parish_id', $this->parishes);
         }
+
+        // Apply started at date filtering
+        if ($this->startedAt) {
+            $builder->whereDate('started_at', '>=', $this->startedAt->toDateString());
+        }
+
+        // Apply ended at date filtering
+        if ($this->endedAt) {
+            $builder->whereDate('ended_at', '<=', $this->endedAt->toDateString());
+        }
     }
 
     /**
@@ -237,6 +282,8 @@ class OccurrenceFilter extends Filter implements Contracts\OccurrenceFilter
             \implode(',', $this->districts),
             \implode(',', $this->counties),
             \implode(',', $this->parishes),
+            $this->startedAt ? $this->startedAt->toDateTimeString() : null,
+            $this->endedAt ? $this->endedAt->toDateTimeString() : null,
         ]);
     }
 }

--- a/app/Http/Controllers/OccurrenceController.php
+++ b/app/Http/Controllers/OccurrenceController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace VOSTPT\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use VOSTPT\Filters\Contracts\OccurrenceFilter;
 use VOSTPT\Http\Requests\Occurrence\Index;
@@ -59,6 +60,14 @@ class OccurrenceController extends Controller
 
         if ($request->has('parishes')) {
             $filter->withParishes(...$request->input('parishes', []));
+        }
+
+        if ($startedAt = $request->get('started_at')) {
+            $filter->withStartedAt(Carbon::parse($startedAt));
+        }
+
+        if ($endedAt = $request->get('ended_at')) {
+            $filter->withEndedAt(Carbon::parse($endedAt));
         }
 
         $paginator = $this->createPaginator(Occurrence::class, $occurrenceRepository->createQueryBuilder(), $filter);

--- a/app/Http/Requests/Occurrence/Index.php
+++ b/app/Http/Requests/Occurrence/Index.php
@@ -15,7 +15,7 @@ class Index extends Request
      */
     public function rules(): array
     {
-        return [
+        $rules = [
             'page.number' => [
                 'integer',
             ],
@@ -46,6 +46,12 @@ class Index extends Request
             'parishes.*' => [
                 Rule::exists('parishes', 'id'),
             ],
+            'started_at' => [
+                'date_format:Y-m-d',
+            ],
+            'ended_at' => [
+                'date_format:Y-m-d',
+            ],
             'sort' => [
                 Rule::in(OccurrenceFilter::getSortableColumns()),
             ],
@@ -53,5 +59,20 @@ class Index extends Request
                 Rule::in(OccurrenceFilter::getOrderValues()),
             ],
         ];
+
+        if ($this->has('started_at', 'ended_at')) {
+            $rules = \array_merge_recursive($rules, [
+                'started_at' => [
+                    'date_format:Y-m-d',
+                    'before_or_equal:ended_at',
+                ],
+                'ended_at' => [
+                    'date_format:Y-m-d',
+                    'after_or_equal:started_at',
+                ],
+            ]);
+        }
+
+        return $rules;
     }
 }

--- a/public/documentation/occurrences/endpoints.yaml
+++ b/public/documentation/occurrences/endpoints.yaml
@@ -59,6 +59,20 @@ index:
           items:
             type: string
             example: 1
+      - name: started_at
+        in: query
+        description: Start date
+        schema:
+          type: string
+          format: date
+          example: '2012-06-14'
+      - name: ended_at
+        in: query
+        description: End date
+        schema:
+          type: string
+          format: date
+          example: '2012-06-14'
       - name: sort
         in: query
         description: Field used for sorting results

--- a/tests/Integration/Controllers/OccurrenceController/IndexEndpointTest.php
+++ b/tests/Integration/Controllers/OccurrenceController/IndexEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace VOSTPT\Tests\Integration\Controllers\OccurrenceController;
 
+use Carbon\Carbon;
 use VOSTPT\Models\County;
 use VOSTPT\Models\District;
 use VOSTPT\Models\Event;
@@ -68,8 +69,10 @@ class IndexEndpointTest extends TestCase
             'parishes' => [
                 1,
             ],
-            'sort'  => 'id',
-            'order' => 'up',
+            'started_at' => '2000-12-31',
+            'ended_at'   => '2000-01-01',
+            'sort'       => 'id',
+            'order'      => 'up',
         ], [
             'Content-Type' => 'application/vnd.api+json',
         ]);
@@ -100,6 +103,18 @@ class IndexEndpointTest extends TestCase
                     'detail' => 'The exact field must be true or false.',
                     'meta'   => [
                         'field' => 'exact',
+                    ],
+                ],
+                [
+                    'detail' => 'The started at must be a date before or equal to ended at.',
+                    'meta'   => [
+                        'field' => 'started_at',
+                    ],
+                ],
+                [
+                    'detail' => 'The ended at must be a date after or equal to started at.',
+                    'meta'   => [
+                        'field' => 'ended_at',
                     ],
                 ],
                 [
@@ -170,11 +185,16 @@ class IndexEndpointTest extends TestCase
             'county_id' => $county->getKey(),
         ]);
 
+        $yesterday = Carbon::yesterday();
+        $today     = Carbon::now();
+
         $occurrences = factory(Occurrence::class, 20)->make([
-            'event_id'  => $event->getKey(),
-            'type_id'   => $type->getKey(),
-            'status_id' => $status->getKey(),
-            'parish_id' => $parish->getKey(),
+            'event_id'   => $event->getKey(),
+            'type_id'    => $type->getKey(),
+            'status_id'  => $status->getKey(),
+            'parish_id'  => $parish->getKey(),
+            'started_at' => $yesterday,
+            'ended_at'   => $today,
         ]);
 
         factory(ProCivOccurrence::class, 20)->create()->each(function (ProCivOccurrence $proCivOccurrence, $index) use ($occurrences) {
@@ -204,9 +224,11 @@ class IndexEndpointTest extends TestCase
             'parishes' => [
                 $parish->getKey(),
             ],
-            'search' => '0 1 2 3 4 5 6 7 8 9',
-            'sort'   => 'locality',
-            'order'  => 'asc',
+            'started_at' => $yesterday->toDateString(),
+            'ended_at'   => $today->toDateString(),
+            'search'     => '0 1 2 3 4 5 6 7 8 9',
+            'sort'       => 'locality',
+            'order'      => 'asc',
         ], [
             'Content-Type' => 'application/vnd.api+json',
         ]);


### PR DESCRIPTION
## Description
This pull request addresses issue [API-38](https://github.com/vostpt/api/issues/38).

## Task items:
- [X] Added ability to filter `Occurrences` by started/ended dates;
- [X] Updated the documentation;
- [X] Added test coverage for implemented feature;