### PR TITLE
[API-76] Refactor API response cache bust logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Digital Volunteers in Emergency Situations
 [![Build Status](https://travis-ci.com/vostpt/api.svg?branch=master)](https://travis-ci.com/vostpt/api) [![Coverage Status](https://coveralls.io/repos/github/vostpt/api/badge.svg?branch=master)](https://coveralls.io/github/vostpt/api?branch=master)
 
 ## Project setup
-The easiest way to get the API started is through Docker compose.
+The easiest way to get the API started is using Docker compose.
 
 ### Container Matrix
  Service / Project | Container Name | Host:Port
@@ -21,7 +21,7 @@ Make sure to add `api.vost.test` to the `/etc/hosts` file, so it can be properly
 ```
 
 ### Running the infrastructure
-Kickstart the VOST API with the following command:
+Jump start the VOST API with the following command:
 
 ```sh
 docker-compose up --detach --build
@@ -35,14 +35,13 @@ Starting vost_redis   ... done
 Starting vost_mariadb ... done
 ```
 
-### Command Line Interface
 In order to run commands (`composer`, `artisan`, ...) in the **API** container, log into it via:
 
 ```sh
 docker exec -it vost_api bash
 ```
 
-Once the infrastructure is running for the first time, finish up by installing the dependencies and setting `.env` file values.
+Once logged in, finish the configuration by following these steps:
 
 Install dependencies:
 ```sh
@@ -59,53 +58,33 @@ Generate an encryption key:
 php artisan key:generate
 ```
 
-Generate JWT secret key:
+Generate a JWT secret key:
 ```sh
 php artisan jwt:secret
 ```
 
-## Occurrences
-Some occurrences are ingested from third party API/web services. In order to fetch those, service clients will be periodically executed.
+Execute the migrations and seeders:
+```sh
+php artisan migrate:fresh --seed
+```
 
-Make sure the main job scheduler is properly set in the system cron table:
+### Jobs/Tasks & Commands
+In order to run the scheduled tasks automatically, make sure the main job scheduler is properly set in the system cron table:
 ```txt
-* * * * * cd /path/to/the/api && php artisan schedule:run >> /dev/null 2>&1
+* * * * * cd /path/to/the/project/root && php artisan schedule:run >> /dev/null 2>&1
 ```
 
-### ProCiv occurrences
-By default, the `OccurrenceFetcher` job class is executed every 5 (five) minutes through the main scheduler.
+Each available job/task, has a corresponding artisan command for local development and testing purposes.
 
-For local development and testing purposes, a command is also available:
-
-```sh
-php artisan prociv:fetch:occurrences
-```
-
-### IPMA warnings
-By default, the `WarningFetcher` job class is executed every 30 (thirty) minutes through the main scheduler.
-
-For local development and testing purposes, a command is also available:
-
-```sh
-php artisan ipma:fetch:warnings
-```
-
-### IPMA surface observations
-By default, the `SurfaceObservationFetcher` job class is executed every 30 (thirty) minutes through the main scheduler.
-
-For local development and testing purposes, a command is also available:
-
-```sh
-php artisan ipma:fetch:surface-observations
-```
-
->**NOTE:** All Job/Command output will be sent to the application log file (`storage/logs/laravel.log`).
-
-### Database
-Execute the migration and seeders:
-```sh
-php artisan migrate:refresh --seed
-```
+ Scope  | Description                     | Class                       | Runs every | Artisan command
+--------|---------------------------------|-----------------------------|-----------:|-------------------------------------
+ ProCiv | Fetch ProCiv occurrences        | `OccurrenceFetcher`         |  5 minutes | `php artisan prociv:fetch:occurrences`
+ ProCiv | Close ProCiv occurrences        | `OccurrenceCloser`          | 30 minutes | `php artisan prociv:close:occurrences`
+ IPMA   | Fetch IPMA warnings             | `WarningFetcher`            | 30 minutes | `php artisan ipma:fetch:warnings`
+ IPMA   | Fetch IPMA surface observations | `SurfaceObservationFetcher` | 30 minutes | `php artisan ipma:fetch:surface-observations`
+ API    | Bust API response cache         | `ResponseCacheBuster`       |  5 minutes | `php artisan api:bust:response-cache`
+ 
+>**NOTE:** Job/Task & Command output is sent to the application log file (`storage/logs/laravel-YYYY-MM-DD.log`).
 
 ## API documentation
 Documentation for the available API endpoints can be accessed [locally](http://api.vost.test/documentation/) or [online](http://api.vost.pt/documentation/).

--- a/app/Console/Commands/ApiResponseCacheBustCommand.php
+++ b/app/Console/Commands/ApiResponseCacheBustCommand.php
@@ -13,7 +13,7 @@ class ApiResponseCacheBustCommand extends Command
     /**
      * {@inheritDoc}
      */
-    protected $signature = 'api:response-cache:bust';
+    protected $signature = 'api:bust:response-cache';
 
     /**
      * {@inheritDoc}

--- a/app/Console/Commands/ApiResponseCacheBustCommand.php
+++ b/app/Console/Commands/ApiResponseCacheBustCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VOSTPT\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+use VOSTPT\Jobs\Api\ResponseCacheBuster;
+
+class ApiResponseCacheBustCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $signature = 'api:response-cache:bust';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $description = 'Bust API response cache';
+
+    /**
+     * Execute the console command.
+     *
+     * @param BusDispatcher $dispatcher
+     *
+     * @return mixed
+     */
+    public function handle(BusDispatcher $dispatcher)
+    {
+        return $dispatcher->dispatchNow(new ResponseCacheBuster());
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -6,6 +6,7 @@ namespace VOSTPT\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use VOSTPT\Jobs\Api\ResponseCacheBuster;
 use VOSTPT\Jobs\Ipma\SurfaceObservationFetcher;
 use VOSTPT\Jobs\Ipma\WarningFetcher;
 use VOSTPT\Jobs\ProCiv\OccurrenceCloser;
@@ -23,10 +24,16 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        // Fetch/Close ProCiv occurrences
         $schedule->job(new OccurrenceFetcher())->everyFiveMinutes();
         $schedule->job(new OccurrenceCloser())->everyThirtyMinutes();
+
+        // Fetch IPMA warnings and surface observations
         $schedule->job(new WarningFetcher())->everyThirtyMinutes();
         $schedule->job(new SurfaceObservationFetcher())->everyThirtyMinutes();
+
+        // Bust the API response cache
+        $schedule->job(new ResponseCacheBuster())->everyFiveMinutes();
     }
 
     /**

--- a/app/Jobs/Api/ResponseCacheBuster.php
+++ b/app/Jobs/Api/ResponseCacheBuster.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VOSTPT\Jobs\Api;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Psr\Log\LoggerInterface;
+
+class ResponseCacheBuster implements ShouldQueue
+{
+    use Dispatchable;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Execute the job.
+     *
+     * @param \Psr\Log\LoggerInterface               $logger
+     * @param \Illuminate\Contracts\Cache\Repository $cache
+     *
+     * @throws \Exception
+     *
+     * @return bool
+     */
+    public function handle(LoggerInterface $logger, Cache $cache): bool
+    {
+        if ($tags = get_cache_bust_tags()) {
+            $logger->info(\sprintf('Busting API response cache for: %s', \implode(', ', $tags)));
+
+            if ($cache->tags($tags)->flush()) {
+                $logger->info(\sprintf('Clearing bust tags for: %s', \implode(', ', $tags)));
+
+                return clear_cache_bust_tags();
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Models/Observers/CacheableObserver.php
+++ b/app/Models/Observers/CacheableObserver.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace VOSTPT\Models\Observers;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 
 class CacheableObserver
 {
@@ -15,11 +13,13 @@ class CacheableObserver
      *
      * @param Model $model
      *
+     * @throws \Exception
+     *
      * @return void
      */
     public function created(Model $model): void
     {
-        $this->flushCache($model);
+        $this->markForCacheBust($model);
     }
 
     /**
@@ -27,11 +27,13 @@ class CacheableObserver
      *
      * @param Model $model
      *
+     * @throws \Exception
+     *
      * @return void
      */
     public function updated(Model $model): void
     {
-        $this->flushCache($model);
+        $this->markForCacheBust($model);
     }
 
     /**
@@ -39,26 +41,26 @@ class CacheableObserver
      *
      * @param Model $model
      *
+     * @throws \Exception
+     *
      * @return void
      */
     public function deleted(Model $model): void
     {
-        $this->flushCache($model);
+        $this->markForCacheBust($model);
     }
 
     /**
-     * Flush the cache of a model class.
+     * Mark cache for bust.
      *
      * @param Model $model
      *
+     * @throws \Exception
+     *
      * @return void
      */
-    private function flushCache(Model $model): void
+    private function markForCacheBust(Model $model): void
     {
-        $tag = \get_class($model);
-
-        Log::info(\sprintf('Flushing "%s" cache', $tag));
-
-        Cache::tags($tag)->flush();
+        add_cache_bust_tag(\get_class($model));
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -23,3 +23,58 @@ if (! \function_exists('joined')) {
         return false;
     }
 }
+
+if (! \function_exists('get_cache_bust_tags')) {
+
+    /**
+     * Get the current cache bust tags.
+     *
+     * @throws Exception
+     *
+     * @return array
+     */
+    function get_cache_bust_tags(): array
+    {
+        return cache('tags_for_cache_busting', []);
+    }
+}
+
+if (! \function_exists('add_cache_bust_tag')) {
+
+    /**
+     * Add a cache bust tag.
+     *
+     * @param string $tag
+     *
+     * @throws Exception
+     *
+     * @return bool
+     */
+    function add_cache_bust_tag(string $tag): bool
+    {
+        $tags = \array_unique(get_cache_bust_tags());
+
+        if (\in_array($tag, $tags, true)) {
+            return true;
+        }
+
+        return cache()->forever('tags_for_cache_busting', \array_merge($tags, [
+            $tag,
+        ]));
+    }
+}
+
+if (! \function_exists('clear_cache_bust_tags')) {
+
+    /**
+     * Clear the cache bust tags.
+     *
+     * @throws Exception
+     *
+     * @return bool
+     */
+    function clear_cache_bust_tags(): bool
+    {
+        return cache()->forget('tags_for_cache_busting');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,10 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
+        <testsuite name="API Commands Integration Tests">
+            <directory suffix="Test.php">./tests/Integration/Commands/Api</directory>
+        </testsuite>
+
         <testsuite name="IPMA Commands Integration Tests">
             <directory suffix="Test.php">./tests/Integration/Commands/Ipma</directory>
         </testsuite>

--- a/tests/Integration/Commands/Api/ResponseCacheBustCommandTest.php
+++ b/tests/Integration/Commands/Api/ResponseCacheBustCommandTest.php
@@ -21,7 +21,7 @@ class ResponseCacheBustCommandTest extends TestCase
     {
         $this->assertFalse(Cache::has('tags_for_cache_busting'));
 
-        $this->artisan('api:response-cache:bust');
+        $this->artisan('api:bust:response-cache');
 
         $this->assertFalse(Cache::has('tags_for_cache_busting'));
     }
@@ -37,7 +37,7 @@ class ResponseCacheBustCommandTest extends TestCase
 
         $this->assertTrue(Cache::has('tags_for_cache_busting'));
 
-        $this->artisan('api:response-cache:bust');
+        $this->artisan('api:bust:response-cache');
 
         $this->assertFalse(Cache::has('tags_for_cache_busting'));
     }

--- a/tests/Integration/Commands/Api/ResponseCacheBustCommandTest.php
+++ b/tests/Integration/Commands/Api/ResponseCacheBustCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VOSTPT\Tests\Integration\Commands\Ipma;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use VOSTPT\Tests\Integration\HttpClientMocker;
+use VOSTPT\Tests\Integration\TestCase;
+
+class ResponseCacheBustCommandTest extends TestCase
+{
+    use HttpClientMocker;
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function itDoesNotBustsResponseCache(): void
+    {
+        $this->assertFalse(Cache::has('tags_for_cache_busting'));
+
+        $this->artisan('api:response-cache:bust');
+
+        $this->assertFalse(Cache::has('tags_for_cache_busting'));
+    }
+
+    /**
+     * @test
+     */
+    public function itSuccessfullyBustsResponseCache(): void
+    {
+        $this->assertFalse(Cache::has('tags_for_cache_busting'));
+
+        add_cache_bust_tag('foo');
+
+        $this->assertTrue(Cache::has('tags_for_cache_busting'));
+
+        $this->artisan('api:response-cache:bust');
+
+        $this->assertFalse(Cache::has('tags_for_cache_busting'));
+    }
+}


### PR DESCRIPTION
## Description
This pull request addresses issue [API-76](https://github.com/vostpt/api/issues/76).

## Task items:
- [X] Add helpers to keep track of cache busting tags;
- [X] Refactor `CacheableObserver` class;
- [X] Add `ResponseCacheBuster` job class;
- [X] Add API response cache buster artisan command;
- [x] Update README;
- [X] Add test coverage for response cache bust command;
