### PR TITLE
[FEAT] Replace Guzzle specific service provider with PSR-18 Client implementation

### DIFF
--- a/app/Jobs/Ipma/SurfaceObservationFetcher.php
+++ b/app/Jobs/Ipma/SurfaceObservationFetcher.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace VOSTPT\Jobs\Ipma;
 
 use Carbon\Carbon;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use VOSTPT\Models\WeatherObservation;
 use VOSTPT\Models\WeatherStation;
 use VOSTPT\Repositories\Contracts\WeatherObservationRepository;
@@ -87,7 +88,7 @@ class SurfaceObservationFetcher implements ShouldQueue
 
         try {
             $results = $this->serviceClient->getSurfaceObservations();
-        } catch (GuzzleException $exception) {
+        } catch (HttpException|ClientExceptionInterface $exception) {
             $this->logger->error($exception->getMessage());
 
             return false;

--- a/app/Jobs/Ipma/SurfaceObservationFetcher.php
+++ b/app/Jobs/Ipma/SurfaceObservationFetcher.php
@@ -88,7 +88,7 @@ class SurfaceObservationFetcher implements ShouldQueue
 
         try {
             $results = $this->serviceClient->getSurfaceObservations();
-        } catch (HttpException|ClientExceptionInterface $exception) {
+        } catch (HttpException | ClientExceptionInterface $exception) {
             $this->logger->error($exception->getMessage());
 
             return false;

--- a/app/Jobs/Ipma/WarningFetcher.php
+++ b/app/Jobs/Ipma/WarningFetcher.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace VOSTPT\Jobs\Ipma;
 
 use Carbon\Carbon;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use VOSTPT\Models\County;
 use VOSTPT\Repositories\Contracts\CountyRepository;
 use VOSTPT\ServiceClients\Contracts\IpmaApiServiceClient;
@@ -133,7 +134,7 @@ class WarningFetcher implements ShouldQueue
 
         try {
             $results = $this->serviceClient->getWarnings();
-        } catch (GuzzleException $exception) {
+        } catch (HttpException|ClientExceptionInterface $exception) {
             $this->logger->error($exception->getMessage());
 
             return false;

--- a/app/Jobs/Ipma/WarningFetcher.php
+++ b/app/Jobs/Ipma/WarningFetcher.php
@@ -134,7 +134,7 @@ class WarningFetcher implements ShouldQueue
 
         try {
             $results = $this->serviceClient->getWarnings();
-        } catch (HttpException|ClientExceptionInterface $exception) {
+        } catch (HttpException | ClientExceptionInterface $exception) {
             $this->logger->error($exception->getMessage());
 
             return false;

--- a/app/Jobs/ProCiv/OccurrenceFetcher.php
+++ b/app/Jobs/ProCiv/OccurrenceFetcher.php
@@ -67,9 +67,10 @@ class OccurrenceFetcher implements ShouldQueue
      * @param ParishRepository           $parishRepository
      * @param \Psr\Log\LoggerInterface   $logger
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return bool
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function handle(
         ProCivWebsiteServiceClient $serviceClient,
@@ -96,9 +97,10 @@ class OccurrenceFetcher implements ShouldQueue
     /**
      * Fetch ProCiv occurrences.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return bool
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     private function fetchProCivOccurrences(): bool
     {
@@ -162,9 +164,10 @@ class OccurrenceFetcher implements ShouldQueue
     /**
      * Fetch ProCiv occurrence details.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return bool
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     private function fetchProCivOccurrenceDetails(): bool
     {

--- a/app/Providers/HttpClientServiceProvider.php
+++ b/app/Providers/HttpClientServiceProvider.php
@@ -4,23 +4,27 @@ declare(strict_types=1);
 
 namespace VOSTPT\Providers;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\RequestOptions;
+use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Psr\Http\Client\ClientInterface;
 
-class GuzzleClientServiceProvider extends ServiceProvider implements DeferrableProvider
+class HttpClientServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
      * {@inheritDoc}
      */
     public function register(): void
     {
-        $this->app->bind(Client::class, static function () {
-            return new Client([
+        $this->app->bind(ClientInterface::class, static function () {
+            $client = new GuzzleClient([
                 // Do not throw exceptions on HTTP 4xx/5xx status
                 RequestOptions::HTTP_ERRORS => false,
             ]);
+
+            return new GuzzleAdapter($client);
         });
     }
 
@@ -30,7 +34,7 @@ class GuzzleClientServiceProvider extends ServiceProvider implements DeferrableP
     public function provides(): array
     {
         return [
-            Client::class,
+            ClientInterface::class,
         ];
     }
 }

--- a/app/Providers/ServiceClientServiceProvider.php
+++ b/app/Providers/ServiceClientServiceProvider.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace VOSTPT\Providers;
 
-use GuzzleHttp\Client;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Psr\Http\Client\ClientInterface;
 use VOSTPT\ServiceClients\Contracts\IpmaApiServiceClient as IpmaApiServiceClientContract;
 use VOSTPT\ServiceClients\Contracts\ProCivWebsiteServiceClient as ProCivWebsiteServiceClientContract;
 use VOSTPT\ServiceClients\IpmaApiServiceClient;
@@ -21,12 +21,12 @@ class ServiceClientServiceProvider extends ServiceProvider implements Deferrable
     {
         // IPMA API service client
         $this->app->singleton(IpmaApiServiceClientContract::class, static function ($app) {
-            return new IpmaApiServiceClient($app[Client::class], $app['config']['services.ipma.api.hostname']);
+            return new IpmaApiServiceClient($app[ClientInterface::class], $app['config']['services.ipma.api.hostname']);
         });
 
         // ProCiv Website service client
         $this->app->singleton(ProCivWebsiteServiceClientContract::class, static function ($app) {
-            return new ProCivWebsiteServiceClient($app[Client::class], $app['config']['services.prociv.website.hostname']);
+            return new ProCivWebsiteServiceClient($app[ClientInterface::class], $app['config']['services.prociv.website.hostname']);
         });
     }
 

--- a/app/ServiceClients/Contracts/IpmaApiServiceClient.php
+++ b/app/ServiceClients/Contracts/IpmaApiServiceClient.php
@@ -9,18 +9,20 @@ interface IpmaApiServiceClient extends ServiceClient
     /**
      * Get warnings.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return array
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function getWarnings(): array;
 
     /**
      * Get surface observations.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return array
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function getSurfaceObservations(): array;
 }

--- a/app/ServiceClients/Contracts/ProCivWebsiteServiceClient.php
+++ b/app/ServiceClients/Contracts/ProCivWebsiteServiceClient.php
@@ -9,18 +9,20 @@ interface ProCivWebsiteServiceClient extends ServiceClient
     /**
      * Get main occurrences.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return array
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function getMainOccurrences(): array;
 
     /**
      * Get occurrence history.
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return array
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function getOccurrenceHistory(): array;
 }

--- a/app/ServiceClients/Contracts/ServiceClient.php
+++ b/app/ServiceClients/Contracts/ServiceClient.php
@@ -41,10 +41,10 @@ interface ServiceClient
      * @param array  $parameters
      * @param array  $headers
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
-     *
      * @return \Psr\Http\Message\ResponseInterface|mixed
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function request(string $method, string $path, array $parameters = [], array $headers = []);
 
@@ -55,9 +55,10 @@ interface ServiceClient
      * @param array  $parameters
      * @param array  $headers
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return \Psr\Http\Message\ResponseInterface|mixed
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function get(string $path, array $parameters = [], array $headers = []);
 
@@ -68,9 +69,10 @@ interface ServiceClient
      * @param array  $parameters
      * @param array  $headers
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return \Psr\Http\Message\ResponseInterface|mixed
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function post(string $path, array $parameters = [], array $headers = []);
 
@@ -81,9 +83,10 @@ interface ServiceClient
      * @param array  $parameters
      * @param array  $headers
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return \Psr\Http\Message\ResponseInterface|mixed
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function put(string $path, array $parameters = [], array $headers = []);
 
@@ -94,9 +97,10 @@ interface ServiceClient
      * @param array  $parameters
      * @param array  $headers
      *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     *
      * @return \Psr\Http\Message\ResponseInterface|mixed
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function delete(string $path, array $parameters = [], array $headers = []);
 }

--- a/app/ServiceClients/ServiceClient.php
+++ b/app/ServiceClients/ServiceClient.php
@@ -64,17 +64,22 @@ abstract class ServiceClient implements Contracts\ServiceClient
      * Parse the service response.
      *
      * @param \Psr\Http\Message\ResponseInterface $response
+     * @param \Psr\Http\Message\RequestInterface  $request
      *
      * @return mixed
      *
      * @throws HttpException
      */
-    protected function parseResponse(ResponseInterface $response)
+    protected function parseResponse(ResponseInterface $response, RequestInterface $request)
     {
         $code = $response->getStatusCode();
 
         if ($code >= 400) {
-            throw new HttpException($code, $response->getReasonPhrase());
+            throw new HttpException($code, \sprintf(
+                '%s (%s)',
+                $request->getUri(),
+                $response->getReasonPhrase()
+            ));
         }
 
         return \json_decode($response->getBody()->getContents(), true);
@@ -116,7 +121,7 @@ abstract class ServiceClient implements Contracts\ServiceClient
 
         $response = $this->httpClient->sendRequest($request);
 
-        return $this->parseResponse($response);
+        return $this->parseResponse($response, $request);
     }
 
     /**

--- a/app/ServiceClients/ServiceClient.php
+++ b/app/ServiceClients/ServiceClient.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace VOSTPT\ServiceClients;
 
-use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -15,7 +16,7 @@ abstract class ServiceClient implements Contracts\ServiceClient
     /**
      * HTTP client.
      *
-     * @var HttpClient
+     * @var ClientInterface
      */
     protected $httpClient;
 
@@ -27,14 +28,12 @@ abstract class ServiceClient implements Contracts\ServiceClient
     protected $hostname;
 
     /**
-     * Service client constructor.
+     * @param ClientInterface $httpClient
+     * @param string          $hostname
      *
-     * @param HttpClient $httpClient
-     * @param string     $hostname
-     *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public function __construct(HttpClient $httpClient, string $hostname)
+    public function __construct(ClientInterface $httpClient, string $hostname)
     {
         if (\filter_var($hostname, FILTER_VALIDATE_URL) === false) {
             throw new InvalidArgumentException('Invalid hostname: '.$hostname);
@@ -66,9 +65,9 @@ abstract class ServiceClient implements Contracts\ServiceClient
      *
      * @param \Psr\Http\Message\ResponseInterface $response
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
-     *
      * @return mixed
+     *
+     * @throws HttpException
      */
     protected function parseResponse(ResponseInterface $response)
     {
@@ -85,6 +84,7 @@ abstract class ServiceClient implements Contracts\ServiceClient
      * Check if the request requires body data.
      *
      * @param string $method
+     *
      * @return bool
      */
     protected function requiresBody(string $method): bool
@@ -114,7 +114,7 @@ abstract class ServiceClient implements Contracts\ServiceClient
 
         $request = new Request($method, $url, \array_merge($headers, $this->getDefaultHeaders()), $body ?? null);
 
-        $response = $this->httpClient->send($request);
+        $response = $this->httpClient->sendRequest($request);
 
         return $this->parseResponse($response);
     }

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "ext-zip": "*",
         "ext-redis": "*",
+        "ext-zip": "*",
         "box/spout": "^3.0",
         "fideloper/proxy": "^4.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "laravel/framework": "^6.2",
+        "laravel/framework": "^6.9",
+        "php-http/guzzle6-adapter": "^2.0",
         "silber/bouncer": "v1.0.0-rc.6",
         "tobscure/json-api": "^0.4.1",
         "tymon/jwt-auth": "1.0.0-rc.5"
@@ -33,6 +33,7 @@
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^3.0",
         "php-coveralls/php-coveralls": "^2.1",
+        "php-http/mock-client": "^1.3",
         "phpunit/phpunit": "^8.0",
         "roave/security-advisories": "dev-master"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ac06a070f44748084f714f4e8deab9a",
+    "content-hash": "64b1d028528e1e2091877fafd6c06d05",
     "packages": [
         {
             "name": "box/spout",
@@ -1210,6 +1210,176 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "6074a4b1f4d5c21061b70bab3b8ad484282fe31f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/6074a4b1f4d5c21061b70bab3b8ad484282fe31f",
+                "reference": "6074a4b1f4d5c21061b70bab3b8ad484282fe31f",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": "^7.1",
+                "php-http/httplug": "^2.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0",
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^2.0",
+                "phpunit/phpunit": "^7.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "time": "2018-12-16T14:44:03+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "72d2b129a48f0490d55b7f89be0d6aa0597ffb06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/72d2b129a48f0490d55b7f89be0d6aa0597ffb06",
+                "reference": "72d2b129a48f0490d55b7f89be0d6aa0597ffb06",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "php-http/promise": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1",
+                "phpspec/phpspec": "^4.3.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "time": "2019-12-27T10:07:11+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "shasum": ""
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-01-26T13:27:02+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.7.2",
             "source": {
@@ -1312,6 +1482,55 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/496a823ef742b632934724bf769560c2a5c7c44e",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2018-10-30T23:29:13+00:00"
         },
         {
             "name": "psr/http-message",
@@ -3427,6 +3646,58 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/stream-filter",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-stream-filter.git",
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A simple and modern approach to stream filtering in PHP",
+            "homepage": "https://github.com/clue/php-stream-filter",
+            "keywords": [
+                "bucket brigade",
+                "callback",
+                "filter",
+                "php_user_filter",
+                "stream",
+                "stream_filter_append",
+                "stream_filter_register"
+            ],
+            "time": "2019-04-09T12:31:48+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "1.5.0",
             "source": {
@@ -4573,6 +4844,319 @@
                 "diff"
             ],
             "time": "2018-02-15T16:58:55+00:00"
+        },
+        {
+            "name": "php-http/client-common",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/client-common.git",
+                "reference": "a8b29678d61556f45d6236b1667db16d998ceec5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/a8b29678d61556f45d6236b1667db16d998ceec5",
+                "reference": "a8b29678d61556f45d6236b1667db16d998ceec5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "php-http/httplug": "^2.0",
+                "php-http/message": "^1.6",
+                "php-http/message-factory": "^1.0",
+                "symfony/options-resolver": " ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1.1",
+                "guzzlehttp/psr7": "^1.4",
+                "phpspec/phpspec": "^5.1",
+                "phpspec/prophecy": "^1.8",
+                "sebastian/comparator": "^3.0"
+            },
+            "suggest": {
+                "ext-json": "To detect JSON responses with the ContentTypePlugin",
+                "ext-libxml": "To detect XML responses with the ContentTypePlugin",
+                "php-http/cache-plugin": "PSR-6 Cache plugin",
+                "php-http/logger-plugin": "PSR-3 Logger plugin",
+                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Common HTTP Client implementations and tools for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "common",
+                "http",
+                "httplug"
+            ],
+            "time": "2019-11-18T08:58:18+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82dbef649ccffd8e4f22e1953c3a5265992b83c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82dbef649ccffd8e4f22e1953c3a5265992b83c0",
+                "reference": "82dbef649ccffd8e4f22e1953c3a5265992b83c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^4.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2020-01-03T11:25:47+00:00"
+        },
+        {
+            "name": "php-http/message",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message.git",
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message/zipball/ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stream-filter": "^1.4",
+                "php": "^7.1",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^1.0",
+                "coduo/phpspec-data-provider-extension": "^1.0",
+                "ext-zlib": "*",
+                "guzzlehttp/psr7": "^1.0",
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "slim/slim": "^3.0",
+                "zendframework/zend-diactoros": "^1.0"
+            },
+            "suggest": {
+                "ext-zlib": "Used with compressor/decompressor streams",
+                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+                "slim/slim": "Used with Slim Framework PSR-7 implementation",
+                "zendframework/zend-diactoros": "Used with Diactoros Factories"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                },
+                "files": [
+                    "src/filters.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTP Message related tools",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7"
+            ],
+            "time": "2019-08-05T06:55:08+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-12-19T14:08:53+00:00"
+        },
+        {
+            "name": "php-http/mock-client",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/mock-client.git",
+                "reference": "186547be76fe81cc0c0589f9285ef9c8dded9845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/mock-client/zipball/186547be76fe81cc0c0589f9285ef9c8dded9845",
+                "reference": "186547be76fe81cc0c0589f9285ef9c8dded9845",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "php-http/client-common": "^1.9 || ^2.0",
+                "php-http/discovery": "^1.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Mock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Mock HTTP client",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http",
+                "mock",
+                "psr7"
+            ],
+            "time": "2019-11-06T12:49:04+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6461,8 +7045,8 @@
     "platform": {
         "php": "^7.2",
         "ext-json": "*",
-        "ext-zip": "*",
-        "ext-redis": "*"
+        "ext-redis": "*",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/config/app.php
+++ b/config/app.php
@@ -171,7 +171,7 @@ return [
         VOSTPT\Providers\AuthServiceProvider::class,
         VOSTPT\Providers\EventServiceProvider::class,
         VOSTPT\Providers\FilterServiceProvider::class,
-        VOSTPT\Providers\GuzzleClientServiceProvider::class,
+        VOSTPT\Providers\HttpClientServiceProvider::class,
         VOSTPT\Providers\RepositoryServiceProvider::class,
         VOSTPT\Providers\ResponseServiceProvider::class,
         VOSTPT\Providers\RouteServiceProvider::class,

--- a/tests/Integration/Commands/Ipma/SurfaceObservationFetchCommandTest.php
+++ b/tests/Integration/Commands/Ipma/SurfaceObservationFetchCommandTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace VOSTPT\Tests\Integration\Commands\Ipma;
 
-use GuzzleHttp\Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Psr\Log\Test\TestLogger;
@@ -26,7 +26,7 @@ class SurfaceObservationFetchCommandTest extends TestCase
     {
         $response = $this->createHttpResponse('tests/data/Ipma/SurfaceObservations.json');
 
-        $this->app->instance(Client::class, $this->createHttpClient($response));
+        $this->app->instance(ClientInterface::class, $this->createHttpClient($response));
 
         $this->app->instance(LoggerInterface::class, new NullLogger());
 
@@ -60,7 +60,7 @@ class SurfaceObservationFetchCommandTest extends TestCase
     {
         $response = $this->createHttpResponse(null, 404);
 
-        $this->app->instance(Client::class, $this->createHttpClient($response));
+        $this->app->instance(ClientInterface::class, $this->createHttpClient($response));
 
         $this->app->instance(LoggerInterface::class, new TestLogger());
 
@@ -68,6 +68,6 @@ class SurfaceObservationFetchCommandTest extends TestCase
 
         $logger = $this->app[LoggerInterface::class];
 
-        $this->assertTrue($logger->hasRecordThatContains('Client error: `GET https://api.ipma.pt/open-data/observation/meteorology/stations/observations.json` resulted in a `404 Not Found`', 'error'));
+        $this->assertTrue($logger->hasRecordThatContains('https://api.ipma.pt/open-data/observation/meteorology/stations/observations.json (Not Found)', 'error'));
     }
 }

--- a/tests/Integration/Commands/Ipma/WarningFetchCommandTest.php
+++ b/tests/Integration/Commands/Ipma/WarningFetchCommandTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace VOSTPT\Tests\Integration\Commands\Ipma;
 
-use GuzzleHttp\Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Psr\Log\Test\TestLogger;
@@ -22,11 +22,11 @@ class WarningFetchCommandTest extends TestCase
     /**
      * @test
      */
-    public function itSuccessfullyFetchesSurfaceObservations(): void
+    public function itSuccessfullyFetchesWarnings(): void
     {
         $response = $this->createHttpResponse('tests/data/Ipma/Warnings.json');
 
-        $this->app->instance(Client::class, $this->createHttpClient($response));
+        $this->app->instance(ClientInterface::class, $this->createHttpClient($response));
 
         $this->app->instance(LoggerInterface::class, new NullLogger());
 
@@ -44,11 +44,11 @@ class WarningFetchCommandTest extends TestCase
     /**
      * @test
      */
-    public function itFailsToFetchSurfaceObservations(): void
+    public function itFailsToFetchWarnings(): void
     {
         $response = $this->createHttpResponse(null, 404);
 
-        $this->app->instance(Client::class, $this->createHttpClient($response));
+        $this->app->instance(ClientInterface::class, $this->createHttpClient($response));
 
         $this->app->instance(LoggerInterface::class, new TestLogger());
 
@@ -56,6 +56,6 @@ class WarningFetchCommandTest extends TestCase
 
         $logger = $this->app[LoggerInterface::class];
 
-        $this->assertTrue($logger->hasRecordThatContains('Client error: `GET https://api.ipma.pt/json/warnings_www.json` resulted in a `404 Not Found`', 'error'));
+        $this->assertTrue($logger->hasRecordThatContains('https://api.ipma.pt/json/warnings_www.json (Not Found)', 'error'));
     }
 }

--- a/tests/Integration/Commands/ProCiv/OccurrenceCloseCommandTest.php
+++ b/tests/Integration/Commands/ProCiv/OccurrenceCloseCommandTest.php
@@ -20,7 +20,7 @@ class OccurrenceCloseCommandTest extends TestCase
     /**
      * @test
      */
-    public function itSuccessfullyFetchesSurfaceObservations(): void
+    public function itSuccessfullyClosesOccurrences(): void
     {
         $this->app->instance(LoggerInterface::class, new NullLogger());
 

--- a/tests/Integration/Commands/ProCiv/OccurrenceFetchCommandTest.php
+++ b/tests/Integration/Commands/ProCiv/OccurrenceFetchCommandTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace VOSTPT\Tests\Integration\Commands\ProCiv;
 
-use GuzzleHttp\Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use VOSTPT\Models\Occurrence;
@@ -29,7 +29,7 @@ class OccurrenceFetchCommandTest extends TestCase
         $response1 = $this->createHttpResponse('tests/data/ProCiv/OccurrencesByLocation.json');
         $response2 = $this->createHttpResponse('tests/data/ProCiv/MainOccurrences.json');
 
-        $this->app->instance(Client::class, $this->createHttpClient($response1, $response2));
+        $this->app->instance(ClientInterface::class, $this->createHttpClient($response1, $response2));
 
         $this->app->instance(LoggerInterface::class, new NullLogger());
 

--- a/tests/Integration/CreatesApplication.php
+++ b/tests/Integration/CreatesApplication.php
@@ -19,6 +19,9 @@ trait CreatesApplication
 
         $app->make(Kernel::class)->bootstrap();
 
+        // Clear the cache
+        $app['cache.store']->flush();
+
         return $app;
     }
 }

--- a/tests/Integration/HttpClientMocker.php
+++ b/tests/Integration/HttpClientMocker.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace VOSTPT\Tests\Integration;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpClient;
+use Http\Mock\Client as MockHttpClient;
 use Psr\Http\Message\ResponseInterface;
 
 trait HttpClientMocker
@@ -15,13 +14,17 @@ trait HttpClientMocker
     /**
      * @param ResponseInterface[] $responses
      *
-     * @return Client
+     * @return HttpClient
      */
-    protected function createHttpClient(ResponseInterface ...$responses): Client
+    protected function createHttpClient(ResponseInterface ...$responses): HttpClient
     {
-        return new Client([
-            'handler' => HandlerStack::create(new MockHandler($responses)),
-        ]);
+        $httpClient = new MockHttpClient();
+
+        foreach ($responses as $response) {
+            $httpClient->addResponse($response);
+        }
+
+        return $httpClient;
     }
 
     /**


### PR DESCRIPTION
## Description
This pull request replaces the old Guzzle client service provider with a more agnostic PSR-18 HTTP client one.

## Task items:
- [X] Replace Guzzle Service Provider with PSR-18 client one;
- [X] Clear cache before each test;
- [X] Updated tests;

## Requirements (optional)
Requirements when deploying the current work to an environment (`dev`, `staging` or `production`):
- `composer install --no-dev`
